### PR TITLE
corrected a typo with the normalisation of SWq

### DIFF
--- a/delta_Wq.py
+++ b/delta_Wq.py
@@ -502,7 +502,7 @@ class delta_Wq:
 	   Xbar_projection = Xbar_data.dot(projections.T)
 
 	   # Computing the Wasserstein distance from the two projected distribution i.e.the sorted difference
-	   SWq = (1/self.mass**2) * np.power(np.abs(np.sort(X_projection.T, axis=1) - np.sort(Xbar_projection.T, axis=1)), q)
+	   SWq = (1/self.mass**2)**q * np.power(np.abs(np.sort(X_projection.T, axis=1) - np.sort(Xbar_projection.T, axis=1)), q)
 	   
 	   return np.power(SWq.mean(), 1/q)
 


### PR DESCRIPTION
Tried to study the Wasserstein distances as a measure of distribution similarity using a toy model of 2 normal distributions with standard deviations 1 and means of -0.5 and +0.5.  Noticed a dependence of the magnitude of SWq on the values of q and also the mass(normalization).  Corrected typo in the normalisation with 1/m^2 not being taken to the power q initially but then being taken to the power 1/q after summation when calculating the SWq.  The fits before and after the correction are as follows:

[SWq_q0.1_len1000_slices1000_pdf_cdf_sf_fit_master_nofix.pdf](https://github.com/adamdddave/EMD4CPV/files/11849846/SWq_q0.1_len1000_slices1000_pdf_cdf_sf_fit_master_nofix.pdf)
[SWq_q0.1_len1000_slices1000_pdf_cdf_sf_fit_master_fixed.pdf](https://github.com/adamdddave/EMD4CPV/files/11849848/SWq_q0.1_len1000_slices1000_pdf_cdf_sf_fit_master_fixed.pdf)
